### PR TITLE
being less restrictive on dependencies

### DIFF
--- a/gemfiles/rails41.gemfile.lock
+++ b/gemfiles/rails41.gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     localer (0.1.1)
-      dry-initializer (~> 2.3.0)
-      thor (~> 0.20.0)
+      dry-initializer (>= 2.0)
+      thor (>= 0.19)
 
 GEM
   remote: https://rubygems.org/
@@ -70,9 +70,9 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
-    dry-initializer (2.3.0)
+    dry-initializer (2.0.0)
     erubis (2.7.0)
-    ffi (1.9.18)
+    ffi (1.9.21)
     gherkin (5.0.0)
     i18n (0.9.3)
       concurrent-ruby (~> 1.0)
@@ -119,7 +119,7 @@ GEM
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
-    rspec-support (3.7.0)
+    rspec-support (3.7.1)
     rubocop (0.52.1)
       parallel (~> 1.10)
       parser (>= 2.4.0.2, < 3.0)
@@ -135,7 +135,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    thor (0.20.0)
+    thor (0.19.0)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)

--- a/gemfiles/rails42.gemfile.lock
+++ b/gemfiles/rails42.gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     localer (0.1.1)
-      dry-initializer (~> 2.3.0)
-      thor (~> 0.20.0)
+      dry-initializer (>= 2.0)
+      thor (>= 0.19)
 
 GEM
   remote: https://rubygems.org/
@@ -79,9 +79,9 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
-    dry-initializer (2.3.0)
+    dry-initializer (2.0.0)
     erubis (2.7.0)
-    ffi (1.9.18)
+    ffi (1.9.21)
     gherkin (5.0.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -144,7 +144,7 @@ GEM
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
-    rspec-support (3.7.0)
+    rspec-support (3.7.1)
     rubocop (0.52.1)
       parallel (~> 1.10)
       parser (>= 2.4.0.2, < 3.0)
@@ -160,7 +160,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thor (0.20.0)
+    thor (0.19.0)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)

--- a/gemfiles/rails50.gemfile.lock
+++ b/gemfiles/rails50.gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     localer (0.1.1)
-      dry-initializer (~> 2.3.0)
-      thor (~> 0.20.0)
+      dry-initializer (>= 2.0)
+      thor (>= 0.19)
 
 GEM
   remote: https://rubygems.org/
@@ -82,9 +82,9 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
-    dry-initializer (2.3.0)
+    dry-initializer (2.0.0)
     erubis (2.7.0)
-    ffi (1.9.18)
+    ffi (1.9.21)
     gherkin (5.0.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -148,7 +148,7 @@ GEM
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
-    rspec-support (3.7.0)
+    rspec-support (3.7.1)
     rubocop (0.52.1)
       parallel (~> 1.10)
       parser (>= 2.4.0.2, < 3.0)
@@ -164,7 +164,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thor (0.20.0)
+    thor (0.19.0)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)

--- a/gemfiles/rails51.gemfile.lock
+++ b/gemfiles/rails51.gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     localer (0.1.1)
-      dry-initializer (~> 2.3.0)
-      thor (~> 0.20.0)
+      dry-initializer (>= 2.0)
+      thor (>= 0.19)
 
 GEM
   remote: https://rubygems.org/
@@ -82,9 +82,9 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
-    dry-initializer (2.3.0)
+    dry-initializer (2.0.0)
     erubi (1.7.0)
-    ffi (1.9.18)
+    ffi (1.9.21)
     gherkin (5.0.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -148,7 +148,7 @@ GEM
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
-    rspec-support (3.7.0)
+    rspec-support (3.7.1)
     rubocop (0.52.1)
       parallel (~> 1.10)
       parser (>= 2.4.0.2, < 3.0)
@@ -164,7 +164,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thor (0.20.0)
+    thor (0.19.0)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)

--- a/localer.gemspec
+++ b/localer.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "cucumber"
   spec.add_development_dependency "aruba"
 
-  spec.add_dependency "thor", "~> 0.20.0"
-  spec.add_dependency "dry-initializer", "~> 2.3.0"
+  spec.add_dependency "thor", ">= 0.19"
+  spec.add_dependency "dry-initializer", ">= 2.0"
 end


### PR DESCRIPTION
i was trying out localer with our rails app, but the dependency restrictions are too tight.
so it's not actually possible to install through bundler in our case.

there is a similar issue already: https://github.com/aderyabin/localer/issues/1#issuecomment-361690308

cucumber runs fine with the changes to thor and the changelog in dry-initializer only shows additions, so it should be fine as well.