### PR TITLE
allow dumping the error result to a json file

### DIFF
--- a/bin/localer
+++ b/bin/localer
@@ -2,6 +2,7 @@
 
 require "thor"
 require "irb"
+require "json"
 require_relative "../lib/localer"
 
 module Localer
@@ -11,6 +12,7 @@ module Localer
       say Localer::VERSION
     end
 
+    option :json
     desc "check [/path/to/rails/application]", "Check missing translations"
     def check(app_path = Localer::Config::APP_PATH)
       Localer.configure(options.dup.merge(app_path: app_path))
@@ -21,6 +23,7 @@ module Localer
         say "\xE2\x9C\x94 No missing translations found.", :green
       else
         missing_translations = Localer.data.missing_translations
+        File.open(options[:json], 'w') { |f| JSON.dump(missing_translations, f) } if options[:json]
         say "\xE2\x9C\x96 Missing translations found (#{missing_translations.count}):", :red
         missing_translations.each do |tr|
           say "* #{tr}"

--- a/features/simple.feature
+++ b/features/simple.feature
@@ -48,6 +48,19 @@ Scenario: Empty en locale
   When I run checker
   Then the checker should fail
 
+Scenario: Empty en locale creates a json dump
+  Given a "ru" locale file with:
+  """
+  ru:
+    one: один
+  """
+  When I run checker with json
+  Then the checker should fail
+  And the checker should create a json dump with:
+  """
+  ["en.one","us.one"]
+  """
+
 Scenario: Incorrect structure
   Given a "en" locale file with:
   """

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -66,7 +66,7 @@ end
 
 Then /^the checker should create a json dump with:$/ do |file_content|
   file_name = 'tmp/aruba/output.json'
-  output = File.exists?(file_name) ? File.read(file_name) : ''
+  output = File.exist?(file_name) ? File.read(file_name) : ''
   expect(output).to eql(file_content)
 end
 

--- a/features/step_definitions/additional_cli_steps.rb
+++ b/features/step_definitions/additional_cli_steps.rb
@@ -64,6 +64,12 @@ Then /^the checker should fail$/ do
   step 'the exit status should be 1'
 end
 
+Then /^the checker should create a json dump with:$/ do |file_content|
+  file_name = 'tmp/aruba/output.json'
+  output = File.exists?(file_name) ? File.read(file_name) : ''
+  expect(output).to eql(file_content)
+end
+
 Then /^the checker should returns (.*) missing translations:$/ do |int, translations|
   step %{the output should contain "✖ Missing translations found (#{int})"}
   translations.raw.each do |tr|
@@ -80,4 +86,8 @@ end
 
 When /^I run checker$/ do
   run("localer check ../../spec/dummy_app")
+end
+
+When /^I run checker with json$/ do
+  run("localer check ../../spec/dummy_app --json output.json")
 end


### PR DESCRIPTION
in order to post-process the result of the check, it would be great if one could dump it into some structured data. i picked json for no particular reason.

ideally, the output would also include things such as: 

* where the information was obtained
* already existing translations for that key

the idea behind this is that i could hook up a translation service and suggest translations within a failed build, or even automate the first translation based on a given locale.