### PR TITLE
Use default options, if config file is empty

### DIFF
--- a/features/locale_option.feature
+++ b/features/locale_option.feature
@@ -35,3 +35,14 @@ Scenario: Disable en.population
    | en.countries.france.population |
    | en.population.france |
 
+Scenario: With empty config file
+  Given a real locales
+  Given a config file with:
+  """
+  """
+  When I run checker
+  Then the checker should returns 4 missing translations:
+   | ru.population.italy |
+   | us.population.italy |
+   | en.countries.france.population |
+   | en.population.france |

--- a/lib/localer/config.rb
+++ b/lib/localer/config.rb
@@ -29,6 +29,7 @@ module Localer # :nodoc:
       def file_config(filename, path)
         filename = File.expand_path(filename, path)
         return {} unless File.exist?(filename)
+        return {} if File.zero?(filename)
         YAML
           .load_file(filename)
           .deep_downcase_keys


### PR DESCRIPTION
I've encountered an issue when my config file was empty.

```
      +/Users/alxgol/OneDrive/Projects/localer/lib/localer/config.rb:36:in `file_config': undefined method `deep_downcase_keys' for false:FalseClass (NoMethodError)
      + from /Users/alxgol/OneDrive/Projects/localer/lib/localer/config.rb:25:in `load'
      + from /Users/alxgol/OneDrive/Projects/localer/lib/localer.rb:23:in `configure'
      + from /Users/alxgol/OneDrive/Projects/localer/bin/localer:16:in `check'
      + from /Users/alxgol/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
      + from /Users/alxgol/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
      + from /Users/alxgol/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
      + from /Users/alxgol/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
      + from /Users/alxgol/OneDrive/Projects/localer/bin/localer:46:in `<main>'
       (RSpec::Expectations::ExpectationNotMetError)
      ./features/step_definitions/additional_cli_steps.rb:68:in `/^the checker should returns (.*) missing translations:$/'
      features/locale_option.feature:44:in `Then the checker should returns 4 missing translations:'
```
Think, that it'd be OK if empty config file will behave in the same way as it already works when there is no file at all