### PR TITLE
Downcase app locales codes when comparing config

### DIFF
--- a/lib/localer/data/processor.rb
+++ b/lib/localer/data/processor.rb
@@ -18,7 +18,7 @@ module Localer # :nodoc:
         @data = Hash.new { |hsh, key| hsh[key] = {} }
         @locales = []
         translations.each do |(locale, translation)|
-          next unless config.locale[locale].enabled
+          next unless config.locale[locale.downcase].enabled
           @locales.push locale
           prepare(locale, translation)
         end
@@ -41,7 +41,7 @@ module Localer # :nodoc:
       end
 
       def exclude?(key, locale)
-        (config.exclude + config.locale[locale].exclude).any? do |pattern|
+        (config.exclude + config.locale[locale.downcase].exclude).any? do |pattern|
           match?(key, pattern)
         end
       end


### PR DESCRIPTION
Downcases the app's locale codes (e.g. zh-CN -> zh-cn) before comparing
to the keys under Locale in `.localer.yml` which are downcased on load.
This makes it possible to configure e.g. zh-CN

I haven't added tests for the behaviour as I wasn't sure if this is the best way of going about it - maybe upcase one of the keys in the `a real locales` Given ?